### PR TITLE
Virheellisen kielikoodin korjaus.

### DIFF
--- a/vtj/vtj-service/src/main/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludge.java
+++ b/vtj/vtj-service/src/main/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludge.java
@@ -1,0 +1,31 @@
+package fi.vm.sade.rajapinnat.vtj.service.impl;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class KielikoodiKludge {
+
+    static final String HEPREA_VIRHEELLINEN = "iw"; // tämähän on ihan hepreaa!
+    static final String HEPREA_KORJATTU = "he";
+
+    private static final Map<String,String> VIRHEELLINEN_KORJATTU = new TreeMap<>();
+    static {
+        VIRHEELLINEN_KORJATTU.put(HEPREA_VIRHEELLINEN, HEPREA_KORJATTU);
+    }
+
+    /**
+     * Vaihtaa (mahdollisen) virheellisen koodin oikeaan.
+     *
+     * @param kielikoodi kielikoodi.
+     *
+     * @return oikea kielikoodi; joko annettu tai korjattu, mikäli annettu oli virheellinen.
+     */
+    public static String korjaaVirheellinenKoodi(String kielikoodi) {
+        if (kielikoodi == null) {
+            return null;
+        }
+        String korjattu = VIRHEELLINEN_KORJATTU.get(kielikoodi.toLowerCase());
+        return korjattu != null ? korjattu : kielikoodi;
+    }
+
+}

--- a/vtj/vtj-service/src/main/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludge.java
+++ b/vtj/vtj-service/src/main/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludge.java
@@ -21,11 +21,7 @@ public class KielikoodiKludge {
      * @return oikea kielikoodi; joko annettu tai korjattu, mikäli annettu oli virheellinen.
      */
     public static String korjaaVirheellinenKoodi(String kielikoodi) {
-        if (kielikoodi == null) {
-            return null;
-        }
-        String korjattu = VIRHEELLINEN_KORJATTU.get(kielikoodi.toLowerCase());
-        return korjattu != null ? korjattu : kielikoodi;
+        return kielikoodi == null ? null : VIRHEELLINEN_KORJATTU.getOrDefault(kielikoodi.toLowerCase(), kielikoodi);
     }
 
 }

--- a/vtj/vtj-service/src/main/java/fi/vm/sade/rajapinnat/vtj/service/impl/VtjServiceImpl.java
+++ b/vtj/vtj-service/src/main/java/fi/vm/sade/rajapinnat/vtj/service/impl/VtjServiceImpl.java
@@ -119,7 +119,7 @@ public class VtjServiceImpl implements VtjService {
 
         henkilo.setSukupuoli(vtjHenkilo.getSukupuoli().getSukupuolikoodi());
         
-        henkilo.setAidinkieliKoodi(vtjHenkilo.getAidinkieli().getKielikoodi());
+        henkilo.setAidinkieliKoodi(KielikoodiKludge.korjaaVirheellinenKoodi(vtjHenkilo.getAidinkieli().getKielikoodi()));
         
         if (vtjHenkilo.getSahkopostiosoite() != null) {
             henkilo.setSahkoposti(vtjHenkilo.getSahkopostiosoite());

--- a/vtj/vtj-service/src/test/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludgeTest.java
+++ b/vtj/vtj-service/src/test/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludgeTest.java
@@ -1,0 +1,22 @@
+package fi.vm.sade.rajapinnat.vtj.service.impl;
+
+import org.junit.Test;
+
+import static fi.vm.sade.rajapinnat.vtj.service.impl.KielikoodiKludge.HEPREA_VIRHEELLINEN;
+import static fi.vm.sade.rajapinnat.vtj.service.impl.KielikoodiKludge.HEPREA_KORJATTU;
+import static fi.vm.sade.rajapinnat.vtj.service.impl.KielikoodiKludge.korjaaVirheellinenKoodi;
+import static org.junit.Assert.assertEquals;
+
+public class KielikoodiKludgeTest {
+
+    @Test
+    public void korjaaVirheellisenKielikoodin() {
+        assertEquals(HEPREA_KORJATTU, korjaaVirheellinenKoodi(HEPREA_VIRHEELLINEN));
+    }
+
+    @Test
+    public void palauttaaAlkuperaisenKielikoodin() {
+        String kielikoodi = "sv";
+        assertEquals(kielikoodi, korjaaVirheellinenKoodi(kielikoodi));
+    }
+}

--- a/vtj/vtj-service/src/test/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludgeTest.java
+++ b/vtj/vtj-service/src/test/java/fi/vm/sade/rajapinnat/vtj/service/impl/KielikoodiKludgeTest.java
@@ -6,6 +6,7 @@ import static fi.vm.sade.rajapinnat.vtj.service.impl.KielikoodiKludge.HEPREA_VIR
 import static fi.vm.sade.rajapinnat.vtj.service.impl.KielikoodiKludge.HEPREA_KORJATTU;
 import static fi.vm.sade.rajapinnat.vtj.service.impl.KielikoodiKludge.korjaaVirheellinenKoodi;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class KielikoodiKludgeTest {
 
@@ -18,5 +19,10 @@ public class KielikoodiKludgeTest {
     public void palauttaaAlkuperaisenKielikoodin() {
         String kielikoodi = "sv";
         assertEquals(kielikoodi, korjaaVirheellinenKoodi(kielikoodi));
+    }
+
+    @Test
+    public void palauttaaNullin() {
+        assertNull(korjaaVirheellinenKoodi(null));
     }
 }


### PR DESCRIPTION
Rajapinnan palauttaessa vanhentuneen kielikoodin
heprealle ("IW"), vaihdetaan se korrektiin ("HE").